### PR TITLE
Fix blur event in AutoComplete.js

### DIFF
--- a/custom-component/src/component/AutoComplete.js
+++ b/custom-component/src/component/AutoComplete.js
@@ -114,10 +114,7 @@ const AutoComplete = () => {
               placeholder="Please browse here"
               value={inputText}
               onFocus={() => setComboBoxOpended(true)}
-              onBlur={() => setTimeout(() => setComboBoxOpended(false), 100)}
-              // setTimeout 메서드를 사용한 이유 : 다른 태그의 click이벤트 호출 후, 해당 태그의 blur이벤트를 호출하기 위함
-              // blur 이벤트가 먼저 실행되고 click 이벤트가 발생하는 것을 깨달았다.
-              // 때문에, 0.1초의 타이머를 주어 다른 태그의 이벤트가 먼저 일어나고 blur이벤트가 발생할 수 있도록 하였다.
+              onBlur={() => setComboBoxOpended(false)}
               onChange={(e) => setInputText(e.target.value)}
             ></AutoCompleteInput>
             <AutoCompleteCloseIcon onClick={() => setInputText("")}>
@@ -134,7 +131,7 @@ const AutoComplete = () => {
                 return (
                   <SearchResult
                     key={index}
-                    onClick={() => {
+                    onMouseDown={() => {
                       setInputText(data);
                       setComboBoxOpended(false);
                     }}

--- a/custom-component/src/component/Modal.js
+++ b/custom-component/src/component/Modal.js
@@ -80,17 +80,15 @@ const ModalButton = styled.div`
 const Modal = () => {
   const [isModalOpen, setModalOpen] = useState(false);
 
-  const controlModal = () => {
-    return setModalOpen(!isModalOpen);
-  };
-
   return (
     <>
       {isModalOpen ? (
-        <Wrapper onClick={() => controlModal()}>
+        <Wrapper onClick={() => setModalOpen(!isModalOpen)}>
           <ModalContainer onClick={(e) => e.stopPropagation()}>
             <ModalIconContainer>
-              <ModalIcon onClick={() => controlModal()}>&times;</ModalIcon>
+              <ModalIcon onClick={() => setModalOpen(!isModalOpen)}>
+                &times;
+              </ModalIcon>
             </ModalIconContainer>
             <ModalTextContainer>Hello CodeStates!</ModalTextContainer>
           </ModalContainer>
@@ -99,7 +97,10 @@ const Modal = () => {
       <FeatureContainer>
         Modal
         <Feature>
-          <ModalButton onClick={() => controlModal()}> Open Modal</ModalButton>
+          <ModalButton onClick={() => setModalOpen(!isModalOpen)}>
+            {" "}
+            Open Modal
+          </ModalButton>
         </Feature>
       </FeatureContainer>
     </>

--- a/custom-component/src/component/Toggle.js
+++ b/custom-component/src/component/Toggle.js
@@ -37,19 +37,19 @@ const ToggleContainerShadow = styled.div`
   border-radius: 20px;
   background-color: ${(props) => (props.isToggleOn ? "none" : "#dcdcdc")};
   box-shadow: ${(props) =>
-    props.isToggleOn ? "100px 0 0 0 #4a19cd inset" : "none"};
-  transition: 0.6s;
+    props.isToggleOn ? "50px 0 0 0 #4a19cd inset" : "none"};
+  transition: 0.3s;
 `;
 
 const ToggleBall = styled.div`
   position: relative;
-  width: 35%;
-  height: 70%;
+  width: 30px;
+  height: 30px;
   transform: ${(props) =>
-    props.isToggleOn ? "translate(170% ,0%)" : "translate(20% ,0%)"};
+    props.isToggleOn ? "translate(45px ,0%)" : "translate(5px ,0%)"};
   border-radius: 50px;
   background-color: white;
-  transition: 0.6s;
+  transition: 0.3s;
 `;
 
 const Toggle = () => {


### PR DESCRIPTION
* 수정사항
1. setTimeout 메서드 제거
수정 전 : click이벤트 후 blur이벤트 발생을 위해 setTimeout을 주었지만 다소 어색한 transition이 발생했음.
또한, 종종 click이벤트가 정상작동하지 않았음.
수정 후 : click이벤트를 mouseDown이벤트로 바꾸면서, 따로 타이머 메서드를 주지 않더라도 blur가 후순위 이벤트가 되었음. 

2. 기타 css 수정
transtion 을 0.6초에서 0.3초로 변경
